### PR TITLE
Travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+dist: trusty
+sudo: required 
+
+language: cpp
+cache: ccache
+  
+install:
+  - sudo apt update
+  - sudo apt install mpi-default-bin mpi-default-dev
+  - export PATH="$HOME/opt/bin:$PATH"
+  - export LD_LIBRARY_PATH="$HOME/opt/lib:$LD_LIBRARY_PATH"
+  - sudo ln -s ccache /usr/local/bin/mpic++
+  - export PATH=/usr/lib/ccache:${PATH}
+  - ccache -s
+# version=master or version=f123f12f3 to select a specific version
+  - CXX="mpic++" .travis/install.plumed
+# patch=lammps-6Apr13 to select a patch
+# patch=no to skip patching
+# repo=https://github.com/gtribello/lammps.git to clone a given repository (rather than official lammps)
+# version=pablo-fix to checkout a specific version
+  - .travis/install.lammps patch=lammps-6Apr13
+  - ccache -s
+
+script:
+  - ./run-tests.sh
+# should add something that makes the script fail when there are errors

--- a/.travis/install.lammps
+++ b/.travis/install.lammps
@@ -1,0 +1,61 @@
+#! /bin/bash
+
+
+version=""
+repo=""
+patch=""
+
+for opt
+do
+case "$opt" in
+  (repo=*) repo="${opt#repo=}" ;;
+  (version=*) version="${opt#version=}" ;;
+  (patch=*) patch="${opt#patch=}" ;;
+  (*) echo "unknown option $opt" ; exit 1 ;;
+esac
+
+done
+
+set -e
+set -x
+
+cd "$(mktemp -dt lammps.XXXXXX)"
+
+if [ -n "$repo" ]; then
+  echo "cloning repository $repo"
+else
+  repo=https://github.com/lammps/lammps.git
+  echo "cloning repository $repo"
+fi
+
+git clone $repo
+cd lammps
+
+if [ -n "$version" ] ; then
+  echo "installing lammps $version"
+else
+  version=$(git tag --sort=-creatordate | grep stable | head -n 1)
+  echo "installing latest stable lammps $version"
+fi
+
+if [ -n "$patch" ] ; then
+  echo "patching using plumed patch $patch"
+else
+  patch="$(plumed patch -l | grep lammps)"
+  echo "patching using plumed patch $patch"
+fi
+
+git checkout $version
+
+if [ "$patch" != no ] ; then
+  plumed patch -p -e $patch
+fi
+
+cd src
+make yes-kspace
+make yes-molecule
+make yes-rigid
+make yes-user-plumed
+make -j 5 ubuntu_simple
+cp ./lmp_ubuntu_simple $HOME/opt/bin/lammps
+

--- a/.travis/install.plumed
+++ b/.travis/install.plumed
@@ -1,0 +1,30 @@
+#! /bin/bash
+
+set -e
+set -x
+
+for opt
+do
+case "$opt" in
+  (version=*) version="${opt#version=}" ;;
+  (*) echo "unknown option $opt" ; exit 1 ;;
+esac
+done
+
+cd "$(mktemp -dt plumed.XXXXXX)"
+
+git clone https://github.com/plumed/plumed2.git
+cd plumed2
+
+if [ -n "$version" ] ; then
+  echo "installing plumed $version"
+else
+  version=$(git tag --sort=-creatordate | grep '^v2\.[0-9][0-9]*\.[0-9][0-9]*' | head -n 1 )
+  echo "installing latest stable plumed $version"
+fi
+
+git checkout $version
+
+./configure --prefix=$HOME/opt
+make -j 5
+make install

--- a/rt-1/check-plumed.sh
+++ b/rt-1/check-plumed.sh
@@ -2,7 +2,7 @@
 
 #!/bin/bash
 
-LAMMPS=/Users/gareth/MD_code/lammps-permanent/lammps/src/lmp_mpi
+LAMMPS=$HOME/opt/bin/lammps
 
 # Run first LAMMPS calculation
 $LAMMPS < in.peptide-plumed

--- a/rt-engforce-npt/check-plumed.sh
+++ b/rt-engforce-npt/check-plumed.sh
@@ -2,7 +2,7 @@
 
 #!/bin/bash
 
-LAMMPS=/Users/gareth/MD_code/lammps-permanent/lammps/src/lmp_mpi
+LAMMPS=$HOME/opt/bin/lammps
 
 # Nothing from here works
 

--- a/rt-engforce/check-plumed.sh
+++ b/rt-engforce/check-plumed.sh
@@ -2,7 +2,7 @@
 
 #!/bin/bash
 
-LAMMPS=/Users/gareth/MD_code/lammps-permanent/lammps/src/lmp_mpi
+LAMMPS=$HOME/opt/bin/lammps
 
 # Nothing from here works
 

--- a/rt-restraint/check-plumed.sh
+++ b/rt-restraint/check-plumed.sh
@@ -2,7 +2,7 @@
 
 #!/bin/bash
 
-LAMMPS=/Users/gareth/MD_code/lammps-permanent/lammps/src/lmp_mpi
+LAMMPS=$HOME/opt/bin/lammps
 
 # Run calculations to test adding restraint on bond
 $LAMMPS < in.peptide-plumed-restraint

--- a/rt-virial/check-plumed.sh
+++ b/rt-virial/check-plumed.sh
@@ -2,7 +2,7 @@
 
 #!/bin/bash
 
-LAMMPS=/Users/gareth/MD_code/lammps-permanent/lammps/src/lmp_mpi
+LAMMPS=$HOME/opt/bin/lammps
 
 # Now run calculations to test virial
 $LAMMPS < in.peptide-plumed-npt


### PR DESCRIPTION
@gtribello @PabloPiaggi

I tried to setup travis tests for Gareth's repository. Gareth: if you enable travis tests (from travis-ci.org) for your repo and merge this it should work. A few comments:
- Compilation for repeated builds is fast since it uses ccache. First build, or build after changing a version might be significantly slower. Anyway, I think it fits well in travis limits.
- Tests are run now but errors are not detected. You should add a command at the end of the travis.yml script to make the script fail if there are errors in the log files.
- Look in the travis.yml file, there is some explanation about how to select a specific plumed or lammps version (just add the proper options to `.travis/install.plumed` and `.travis/install.lammps`). By default it installs the latest stable version for both, which I guess is supposed not to be the right thing.
- Use `.travis/install.lammps patch=lammps-6Apr13` to force a specific patch, whereas `.travis/install.lammps patch=no` does not do any patch (assumes that lammps is already patched)

See a typical run [here](https://travis-ci.org/GiovanniBussi/test-lammps-and-plumed/builds/449791375).

Let me know if you manage to make it work.

Ciao!

Giovanni