### PR TITLE
adding required option `make yes-manybody`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 Regression tests for checking that LAMMPS and PLUMED can work together.  To run these tests you 
 must build lammps with the following options
 
-make yes-kspace
-make yes-molecule
-make yes-rigid
+make yes-kspace;
+make yes-molecule;
+make yes-rigid;
+make yes-manybody;
 make yes-user-plumed


### PR DESCRIPTION
Hi Gareth,
yesterday when using this tests before pulling to the lammps repository, I noticed that one required option was missing from the README: `make yes-manybody`, which is needed by eam/fs in rt-engforce.
ciao!

Michele